### PR TITLE
[新規追加・更新] シーンのマネージャーベースクラスを作成、マップシーンのマネージャーをベースを継承する形に変更

### DIFF
--- a/Source/SpaceExploration/Private/Scene/AC_SceneManagerBase.cpp
+++ b/Source/SpaceExploration/Private/Scene/AC_SceneManagerBase.cpp
@@ -1,0 +1,154 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#include "Scene/AC_SceneManagerBase.h"
+
+#include "Character/PlayerCharacter.h"
+#include "PlayerController/SelectPlanetPlayerController.h"
+#include <Kismet/GameplayStatics.h>
+
+
+
+// Sets default values
+AAC_SceneManagerBase::AAC_SceneManagerBase()
+{
+ 	// Set this actor to call Tick() every frame.  You can turn this off to improve performance if you don't need it.
+	PrimaryActorTick.bCanEverTick = true;
+
+
+}
+
+// Called when the game starts or when spawned
+void AAC_SceneManagerBase::BeginPlay()
+{
+	Super::BeginPlay();
+	
+	// プレイヤーキャラクター取得
+	playerCharacter_ = Cast<APlayerCharacter>(UGameplayStatics::GetPlayerCharacter(GetWorld(), 0));
+
+	if (!playerCharacter_) {
+		UKismetSystemLibrary::PrintString(this, "PlayerCharacter_ is nullptr", true, true, FColor::Red, 3.f);
+		UE_LOG(LogClass, Error, TEXT("AC_StageManager::BeginPlay...PlayerCharacter_ is nullptr"));
+		return;
+	}
+
+
+	// シーケンスマネージャーを生成
+	// ※※※※※※※※※※※※※※※※※※※※※※※※※※※※※※
+	// 継承先で、ChangeSequence関数を用いて実行するデリゲートをセットすること！！！！！！！
+	// ※※※※※※※※※※※※※※※※※※※※※※※※※※※※※※
+	sequenceManager_ = NewObject<USequenceManager>();
+
+	// sequenceManager_についてログ表示
+	if (sequenceManager_ == nullptr) {
+		UE_LOG(LogTemp, Error, TEXT("AC_StageManager::BeginPlay...sequenceManager_ is nullptr"));
+		return;
+	}
+	else {
+		UE_LOG(LogTemp, Log, TEXT("AC_StageManager::BeginPlay...sequenceManager_ generated!"));
+	}
+
+
+
+	// 自身をplayerControllerにセット
+	Cast<ASelectPlanetPlayerController>(UGameplayStatics::GetPlayerController(this, 0))->SetStageMapManager(this);
+
+
+}
+
+// Called every frame
+void AAC_SceneManagerBase::Tick(float DeltaTime)
+{
+	Super::Tick(DeltaTime);
+
+
+	if (sequenceManager_) {
+
+
+		// シーケンスの更新
+		sequenceManager_->updateSequence(DeltaTime);
+
+		// 入力の状態を確認
+		CheckClickInput();
+
+	}
+
+
+}
+
+
+// -----------------------------------------------------------------------------------------------------
+
+// レイを飛ばして当たったActorを取得する関数
+AActor* AAC_SceneManagerBase::PerformRaycast() {
+
+	// ----------------------------------------------------------------------
+	// レイの開始地点と終了地点を定義
+
+	// プレイヤーコントローラー取得
+	APlayerController* playerController = GetWorld()->GetFirstPlayerController();
+	if (!playerController) {
+		return nullptr;
+	}
+
+
+	// カーソルの位置のオブジェクトを取得
+	FHitResult hitResult;
+	if (playerController->GetHitResultUnderCursor(ECC_Visibility, false, hitResult)) {
+		AActor* hitActor = hitResult.GetActor();
+
+		if (hitActor) {
+
+			//UE_LOG(LogTemp, Log, TEXT("Hit Actor: %s"), *hitActor->GetName());
+
+		   // デバッグ用にヒット位置を表示
+			DrawDebugSphere(GetWorld(), hitResult.ImpactPoint, 10.0f, 12, FColor::Red, false, 1.0f);
+
+
+			return hitActor;
+		}
+
+	}
+
+	return nullptr;
+
+}
+
+
+
+
+//------------------------------------------------------------------------------------
+// 入力を確認する用の関数
+
+
+
+// クリック入力を外部から伝えるための関数
+// playerControllerでクリックされたときの処理としてバインドする用
+void AAC_SceneManagerBase::OnClickInput() {
+
+	// 入力が既にある場合は処理しない
+	if (isClickInput_) { return; }
+
+	// 入力があった状態にする
+	isClickInput_ = true;
+
+}
+
+
+// クリック入力を確認する関数
+// クリック入力を必要とする処理と、update関数で毎回isClickInputを確認する
+bool AAC_SceneManagerBase::CheckClickInput() {
+
+	// 入力の状態が入っていないときは処理しない
+	if (!isClickInput_) { return false; }
+
+	else {
+
+		// 入力の状態をリセットする
+		isClickInput_ = false;
+
+		// trueを返す
+		return true;
+	}
+
+}
+

--- a/Source/SpaceExploration/Private/Scene/SelectTileScene/AC_StageMapManager.cpp
+++ b/Source/SpaceExploration/Private/Scene/SelectTileScene/AC_StageMapManager.cpp
@@ -17,7 +17,7 @@
 
 // Sets default values
 AAC_StageMapManager::AAC_StageMapManager()
-    : tileSpace_(500), basePos_({ 0, 0, 0 }), sequenceManager_(nullptr), galaxyRandomSelect_(nullptr), galaxyRandomSelectComponent_(nullptr), tileObjectComponent_(nullptr), hoveredTile_(nullptr),
+    : tileSpace_(500), basePos_({ 0, 0, 0 })/*, sequenceManager_(nullptr)*/, galaxyRandomSelect_(nullptr), galaxyRandomSelectComponent_(nullptr), tileObjectComponent_(nullptr), hoveredTile_(nullptr),
     battleTileClass_(AAC_MapTileBattle::StaticClass()), healTileClass_(AAC_MapTileHeal::StaticClass()), itemTileClass_(AAC_MapTileItem::StaticClass())
 {
  	// Set this actor to call Tick() every frame.  You can turn this off to improve performance if you don't need it.
@@ -44,20 +44,7 @@ AAC_StageMapManager::AAC_StageMapManager()
 void AAC_StageMapManager::BeginPlay()
 {
 
-
-
 	Super::BeginPlay();
-
-    UE_LOG(LogTemp, Log, TEXT("BeginPlay"));
-
-    playerCharacter_ = Cast<APlayerCharacter>(UGameplayStatics::GetPlayerCharacter(GetWorld(), 0));
-
-    if (!playerCharacter_) {
-        UKismetSystemLibrary::PrintString(this, "PlayerCharacter_ is nullptr", true, true, FColor::Red, 3.f);
-        UE_LOG(LogClass, Error, TEXT("PlayerCharacter_ is nullptr"));
-        return;
-    }
-
 
     //-------------------------------------------------------------------------------
     // シーケンス制御用の処理
@@ -70,19 +57,12 @@ void AAC_StageMapManager::BeginPlay()
     executeTileEventDel_ = FSequenceDelegate::CreateUObject(this, &AAC_StageMapManager::SeqExecuteTileEvent);
 
 
-    // 最初に実行する関数を指定
-    sequenceManager_ = NewObject<USequenceManager>();
 
-    if (sequenceManager_ == nullptr) {
-        UE_LOG(LogTemp, Error, TEXT("sequenceManager_ is nullptr"));
-        return;
+    // シーケンスマネージャーが存在するときは初期シーケンスのデリゲートをセット
+    if (sequenceManager_) {
+        sequenceManager_->ChangeSequence(createTileDel_);
     }
 
-    sequenceManager_->ChangeSequence(createTileDel_);
-
-
-    // 自身をplayerControllerにセット
-    Cast<ASelectPlanetPlayerController>(UGameplayStatics::GetPlayerController(this, 0))->SetStageMapManager(this);
 
 }
 
@@ -93,62 +73,9 @@ void AAC_StageMapManager::Tick(float DeltaTime)
 
 
 
-    if (sequenceManager_) {
-
-
-        // シーケンスの更新
-        sequenceManager_->updateSequence(DeltaTime);
-
-        // 入力の状態を確認
-        CheckClickInput();
-
-    }
-    else {
-
-        UE_LOG(LogTemp, Error, TEXT("sequenceManager_ is nullptr"));
-    }
 
 }
 
-
-
-//------------------------------------------------------------------------------------
-// 入力を確認する用の関数
-
-
-
-
-
-// クリック入力を外部から伝えるための関数
-// playerControllerでクリックされたときの処理としてバインドする用
-void AAC_StageMapManager::OnClickInput() {
-
-    // 入力が既にある場合は処理しない
-    if (isClickInput_) { return; }
-
-    // 入力があった状態にする
-    isClickInput_ = true;
-
-}
-
-
-// クリック入力を確認する関数
-// クリック入力を必要とする処理と、update関数で毎回isClickInputを確認する
-bool AAC_StageMapManager::CheckClickInput() {
-
-    // 入力の状態が入っていないときは処理しない
-    if (!isClickInput_) { return false; }
-
-    else {
-
-        // 入力の状態をリセットする
-        isClickInput_ = false;
-
-        // trueを返す
-        return true;
-    }
-
-}
 
 
 
@@ -480,40 +407,3 @@ void AAC_StageMapManager::CreateTileObjArray(TArray<int> createTileNumArray)
 
 
 
-// -----------------------------------------------------------------------------------------------------
-// クリックでオブジェクトを取得するための関数
-
-// レイを飛ばして当たったActorを取得する関数
-AActor* AAC_StageMapManager::PerformRaycast() {
-
-    // ----------------------------------------------------------------------
-    // レイの開始地点と終了地点を定義
-
-    // プレイヤーコントローラー取得
-    APlayerController* playerController = GetWorld()->GetFirstPlayerController();
-    if (!playerController) {
-        return nullptr;
-    }
-
-
-    // カーソルの位置のオブジェクトを取得
-    FHitResult hitResult;
-    if (playerController->GetHitResultUnderCursor(ECC_Visibility, false, hitResult)) {
-        AActor* hitActor = hitResult.GetActor();
-
-        if (hitActor) {
-
-             //UE_LOG(LogTemp, Log, TEXT("Hit Actor: %s"), *hitActor->GetName());
-
-            // デバッグ用にヒット位置を表示
-            DrawDebugSphere(GetWorld(), hitResult.ImpactPoint, 10.0f, 12, FColor::Red, false, 1.0f);
-
-
-            return hitActor;
-        }
-
-    }
-
-    return nullptr;
-
-}

--- a/Source/SpaceExploration/Public/Scene/AC_SceneManagerBase.h
+++ b/Source/SpaceExploration/Public/Scene/AC_SceneManagerBase.h
@@ -1,0 +1,80 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "../Manager/SequenceManager.h"
+
+
+#include "AC_SceneManagerBase.generated.h"
+
+
+
+// シーンマネージャーベースクラス
+// シーン上の動作を管理するためのマネージャークラスのベースとして使用する用
+UCLASS()
+class SPACEEXPLORATION_API AAC_SceneManagerBase : public AActor
+{
+	GENERATED_BODY()
+	
+public:	
+	// Sets default values for this actor's properties
+	AAC_SceneManagerBase();
+
+protected:
+	// Called when the game starts or when spawned
+	virtual void BeginPlay() override;
+
+
+public:
+	// Called every frame
+	virtual void Tick(float DeltaTime) override;
+
+	
+protected:
+
+
+	// プレイヤーの参照
+	UPROPERTY(VisibleAnywhere)
+	class APlayerCharacter* playerCharacter_;
+
+
+	// シーケンスマネージャー
+	// 継承先でこれを利用して処理を行う
+	// 使用例はAC_StageMapManagerを確認すること
+	UPROPERTY(VisibleAnywhere)
+	USequenceManager* sequenceManager_;
+
+
+
+	// レイを飛ばして当たったActorを取得する関数
+	UFUNCTION(BlueprintCallable)
+	AActor* PerformRaycast();
+
+
+//----------------------------------------------------
+// 入力を受け取る処理の関係
+
+public:
+
+	// クリック入力を外部から伝えるための関数
+	// playerControllerでクリックされたときの処理としてバインドする用
+	void OnClickInput();
+
+
+protected:
+
+	// クリック入力があった際に一瞬trueにするための関数
+	// updateで確認してfalseにする
+	UPROPERTY()
+	bool isClickInput_ = false;
+
+
+
+	// クリック入力を確認する関数
+	// クリック入力を必要とする処理と、update関数で毎回isClickInputを確認する
+	bool CheckClickInput();
+
+
+};

--- a/Source/SpaceExploration/Public/Scene/SelectTileScene/AC_StageMapManager.h
+++ b/Source/SpaceExploration/Public/Scene/SelectTileScene/AC_StageMapManager.h
@@ -8,7 +8,7 @@
 #include "../../tsutsumi/GalaxyRandomSelect.h"
 #include "../../Scene/SelectTileScene/E_Tile.h"
 #include "../../Manager/SequenceManager.h"
-
+#include "../AC_SceneManagerBase.h"
 
 #include "AC_StageMapManager.generated.h"
 
@@ -29,8 +29,9 @@ struct FTileArray {
 // 作成者：伊藤
 // ステージマップを管理するためのクラス
 // ステージの配列の生成、保持、取得等の処理を行う
+// 親クラスはSceneManagerBase
 UCLASS(BlueprintType)
-class SPACEEXPLORATION_API AAC_StageMapManager : public AActor
+class SPACEEXPLORATION_API AAC_StageMapManager : public AAC_SceneManagerBase
 {
 	GENERATED_BODY()
 	
@@ -43,39 +44,10 @@ private:
 	virtual void BeginPlay() override;
 
 
-	//------------------------------------------------------------------------------------
-	// 入力を確認する用の関数・変数
-
-
-public :
-
-	// クリック入力を外部から伝えるための関数
-	// playerControllerでクリックされたときの処理としてバインドする用
-	void OnClickInput();
-
-
-private :
-
-	// クリック入力があった際に一瞬trueにするための関数
-	// updateで確認してfalseにする
-	UPROPERTY()
-	bool isClickInput_ = false;
-
-
-
-	// クリック入力を確認する関数
-	// クリック入力を必要とする処理と、update関数で毎回isClickInputを確認する
-	bool CheckClickInput();
-
 
 	//------------------------------------------------------------------------------------
 	// MapSceneの制御用
 	// デリゲートを用いて制御を行う
-
-	// シーケンスマネージャー
-	UPROPERTY(VisibleAnywhere)
-	USequenceManager* sequenceManager_;
-
 
 
 	// シーケンス用の関数とデリゲート
@@ -164,13 +136,11 @@ private :
 	TSubclassOf<class AAC_MapTileItem> itemTileClass_;
 
 
-	// プレイヤーの参照
-	UPROPERTY(EditAnywhere)
-	APlayerCharacter* playerCharacter_;
+	//// プレイヤーの参照
+	//UPROPERTY(EditAnywhere)
+	//APlayerCharacter* playerCharacter_;
 
 
-	// レイを飛ばして当たったActorを取得する関数
-	AActor* PerformRaycast();
 
 	// カーソルが重なっているマス
 	UPROPERTY(VisibleAnywhere)


### PR DESCRIPTION
〇マネージャーベースクラス追加
　以下のMapSceneManagerの機能をベースクラスの機能として分離
　・Sequence処理の機能（各シーケンス・デリゲートは継承先で定義）
　・クリックした際にマウスカーソルの位置のActorを取得する機能

---------------------------------------------------------------------------------------
〇StageMapManagerの変更
　・マネージャーベースクラスを継承する形に変更

---------------------------------------------------------------------------------------
※注意点
PlayerControllerにインスタンスをセットしているので、
PlayerController側のセットする変数の型をSceneManagerBaseクラスに変更すること！