### PR TITLE
[update] 移動できるマスを一つ先の列のマスのみに制限するように変更

### DIFF
--- a/Source/SpaceExploration/Private/Manager/StageDataManager.cpp
+++ b/Source/SpaceExploration/Private/Manager/StageDataManager.cpp
@@ -75,7 +75,6 @@ void AStageDataManager::BeginPlay()
 	GetNiagaraSystemsFromFolder("/Game/graphics/alpha/Master_planet/FX_planet_naiagara");
 
 
-	// CreateTileArray({ 1, 2, 3, 2, 3, 2, 1 });
 }
 
 // Called every frame

--- a/Source/SpaceExploration/Private/Scene/SelectTileScene/AC_MapTile.cpp
+++ b/Source/SpaceExploration/Private/Scene/SelectTileScene/AC_MapTile.cpp
@@ -10,7 +10,7 @@
 
 // Sets default values
 AAC_MapTileBase::AAC_MapTileBase()
-	: isTileEventEnd(false), tileType_(E_TILE_TYPE::NONE)
+	: isTileEventEnd_(false), tileType_(E_TILE_TYPE::NONE)
 {
  	// Set this actor to call Tick() every frame.  You can turn this off to improve performance if you don't need it.
 	PrimaryActorTick.bCanEverTick = true;

--- a/Source/SpaceExploration/Private/Scene/SelectTileScene/AC_StageMapManager.cpp
+++ b/Source/SpaceExploration/Private/Scene/SelectTileScene/AC_StageMapManager.cpp
@@ -20,7 +20,7 @@
 
 // Sets default values
 AAC_StageMapManager::AAC_StageMapManager()
-    : tileSpace_(500), basePos_({ 0, 0, 0 })/*, sequenceManager_(nullptr)*/, galaxyRandomSelect_(nullptr), galaxyRandomSelectComponent_(nullptr)/*, tileObjectComponent_(nullptr)*/, hoveredTile_(nullptr),
+    : tileSpace_(500), basePos_({ 0, 0, 0 }), galaxyRandomSelect_(nullptr), galaxyRandomSelectComponent_(nullptr), hoveredTile_(nullptr),
     battleTileClass_(AAC_MapTileBattle::StaticClass()), healTileClass_(AAC_MapTileHeal::StaticClass()), itemTileClass_(AAC_MapTileItem::StaticClass())
 {
     // Set this actor to call Tick() every frame.  You can turn this off to improve performance if you don't need it.
@@ -179,10 +179,17 @@ void AAC_StageMapManager::SeqCreateTile(const float delta_time) {
     // マップのデータの取得を試みる
     if ( !(playsceneGameMode->GetStageDataManager()->TryGetStageMapData(stageMapData_)) ) {
 
-        UE_LOG(LogTemp, Log, TEXT("stageMapManager::SeqCreateTile　タイルデータ作成"));
-        playsceneGameMode->GetStageDataManager()->CreateTileArray({ 1, 2, 3, 2, 3, 2, 1 });
 
+        // 新たにデータを作成する場合
+
+        UE_LOG(LogTemp, Log, TEXT("stageMapManager::SeqCreateTile　タイルデータ作成"));
+        // データを作成
+        playsceneGameMode->GetStageDataManager()->CreateTileArray({ 1, 2, 3, 2, 3, 2, 1 });
+        // 作成したデータを取得
         playsceneGameMode->GetStageDataManager()->TryGetStageMapData(stageMapData_);
+
+        // 一番手前のマスのみ移動可能にする
+        stageMapData_.tileDataArray_[0].tileDataArray_[0]->SetCanMove(true);
     }
     else {
         UE_LOG(LogTemp, Log, TEXT("stageMapManager::SeqCreateTile　タイルデータ取得"));
@@ -198,6 +205,7 @@ void AAC_StageMapManager::SeqCreateTile(const float delta_time) {
     // 実行するシーケンスを切り替え
     // 切り替え先：マス選択シーケンス
     sequenceManager_->ChangeSequence(selectTileDel_);
+
 
     UE_LOG(LogTemp, Log, TEXT("シーケンス切り替え：selectTileDel_"));
 
@@ -227,6 +235,7 @@ void AAC_StageMapManager::SeqSelectTile(const float delta_time) {
 
             // ログを表示
             UE_LOG(LogTemp, Log, TEXT("HoveredTile: %s"), *hoveredTile_->GetName());
+            UE_LOG(LogTemp, Log, TEXT("canMove: %s"), hoveredTile_->GetCanMove() ? TEXT("true") : TEXT("false"));
         }
 
     }
@@ -244,6 +253,10 @@ void AAC_StageMapManager::SeqSelectTile(const float delta_time) {
     if (!CheckClickInput()) { return; }
     // 重なっているマスが存在しない場合は処理しない
     if (!hoveredTile_) { return; }
+    // 重なっているマスが移動できない状態の時は処理しない
+    if (!hoveredTile_->GetCanMove()) { return; }
+    
+
 
     // ログを表示
     UE_LOG(LogTemp, Log, TEXT("クリック"));
@@ -351,6 +364,33 @@ void AAC_StageMapManager::SeqStartTileEvent(const float delta_time) {
     selectTile_->TileEvent();
 
 
+    // 現在移動可能なマスを移動不可にする
+    for (TObjectPtr<AAC_MapTileBase> tileObj : tileObjArray_[selectTile_->GetTileIndex().Y].TileArray) {
+
+        tileObj->SetCanMove(false);
+
+    }
+    for (UTileData* tileData : stageMapData_.tileDataArray_[selectTile_->GetTileIndex().Y].tileDataArray_) {
+
+        tileData->SetCanMove(false);
+    }
+
+    // まだ先にマスがある時
+    if (selectTile_->GetTileIndex().Y < tileObjArray_.Num() - 1) {
+
+
+        // 現在のマスの一つ先のマスを移動可能にする
+        for (TObjectPtr<AAC_MapTileBase> tileObj : tileObjArray_[selectTile_->GetTileIndex().Y + 1].TileArray) {
+
+            tileObj->SetCanMove(true);
+
+        }
+        for (UTileData* tileData : stageMapData_.tileDataArray_[selectTile_->GetTileIndex().Y + 1].tileDataArray_) {
+
+            tileData->SetCanMove(true);
+        }
+
+    }
 
 
     // ※※※ イベント実行後 ※※※
@@ -371,6 +411,10 @@ void AAC_StageMapManager::SeqTileEventProcess(const float)
     {
         return;
     }
+
+
+
+
 
     sequenceManager_->ChangeSequence(selectTileDel_);
 
@@ -400,30 +444,13 @@ void AAC_StageMapManager::CreateTileObjArray(TArray<int> createTileNumArray)
     tileTypeArray_.Empty();
     tileObjArray_.Empty();
 
-    //if (!galaxyRandomSelect_) {
-    //    UE_LOG(LogTemp, Log, TEXT("stageMapManager::CreateTileObjArray　galaxyRandomSelectがありません"));
-    //    return;
-    //}
+
 
 
     // ゲームモード
     APlaySceneGameModeBase* playsceneGameMode = Cast<APlaySceneGameModeBase>(UGameplayStatics::GetGameMode(GetWorld()));
 
 
-
-    UE_LOG(LogTemp, Log, TEXT("stageMapManager::CreateTileObjArray　createTileNumArray.Num() = %d"), createTileNumArray.Num());
-
-
-    // playsceneGameMode->GetStageDataManager()->CreateTileArray(createTileNumArray);
-
-    // playsceneGameMode->GetStageDataManager()->TryGetStageMapData(stageMapData_);
-
-    //// マスの種類をランダムで生成
-    //tileTypeArray_ = galaxyRandomSelect_->MakeTileArray(createTileNumArray);
-
-
-
-    UE_LOG(LogTemp, Log, TEXT("stageMapManager::CreateTileObjArray　stageMapData_.tileDataArray_[row].Num() = %d"), stageMapData_.tileDataArray_.Num());
 
 
 
@@ -435,18 +462,8 @@ void AAC_StageMapManager::CreateTileObjArray(TArray<int> createTileNumArray)
         // 二重配列に入れる用の仮の配列
         FTileArray tempTileArray;
 
+        // 生成するマス
         AAC_MapTileBase* tempTile;
-
-
-
-
-        //// マスのデータを元にオブジェクトを生成する！！！！！！
-        //stageMapData_.tileDataArray_[row].tileDataArray_[col]->GetTileType();
-
-
-
-        UE_LOG(LogTemp, Log, TEXT("stageMapManager::CreateTileObjArray　stageMapData_.tileDataArray_[row].tileDataArray_.Num() = %d"), stageMapData_.tileDataArray_[row].tileDataArray_.Num());
-
 
 
         // マスのオブジェクトを生成
@@ -491,12 +508,15 @@ void AAC_StageMapManager::CreateTileObjArray(TArray<int> createTileNumArray)
 
             // データに設定されているのナイアガラシステムをオブジェクト自身に設定
             tempTile->SetNiagaraSystem( stageMapData_.tileDataArray_[row].tileDataArray_[col]->GetTileNiagaraSys() );
-
+            // 移動可能かどうかを設定
+            tempTile->SetCanMove(stageMapData_.tileDataArray_[row].tileDataArray_[col]->GetCanMove());
+            // マスのインデックスを設定
+            tempTile->SetTileIndex(FVector2D{ (double)col, (double)row });
 
             // 配列に追加
             tempTileArray.TileArray.Emplace(tempTile);
 
-            // 
+            // 子オブジェクトとして設定
             tempTile->AttachToActor(this, FAttachmentTransformRules::KeepRelativeTransform);
 
 

--- a/Source/SpaceExploration/Private/tsutsumi/GalaxyRandomSelect.cpp
+++ b/Source/SpaceExploration/Private/tsutsumi/GalaxyRandomSelect.cpp
@@ -265,11 +265,18 @@ TArray<FTileEnumArray> AGalaxyRandomSelect::MakeTileArray(TArray<int> tileNumHol
 				continue;
 			}
 
+
+			// 生成するマスの種類の条件
+
 			// 一番後ろのマスの場合はバトルマスにする
 			if (v == tileNumHolizontal.Num() - 1) {
 				
 				tileArray_[v].typeArray[h] = E_TILE_TYPE::BATTLE;
 
+			}
+			// 一番前のマスの場合はアイテムマスにする
+			else if (v == 0) {
+				tileArray_[v].typeArray[h] = E_TILE_TYPE::ITEM;
 			}
 			// そうでないときはランダムに選択する
 			else {

--- a/Source/SpaceExploration/Public/GameData/TileData.h
+++ b/Source/SpaceExploration/Public/GameData/TileData.h
@@ -43,6 +43,11 @@ protected :
 	FVector2D tileArrayIndex_;
 
 
+	// 移動できるかどうかのフラグ
+	UPROPERTY(EditAnywhere)
+	bool canMove_ = false;
+
+
 public :
 
 	// ---------------------------------------------------------------------------------------------
@@ -52,25 +57,38 @@ public :
 	// ゲッター
 
 	// マスの種類のゲッター
-	E_TILE_TYPE GetTileType() { return tileType_; }
+	UFUNCTION(BlueprintCallable)
+	inline E_TILE_TYPE GetTileType() { return tileType_; }
 
 	// マスのナイアガラのゲッター
-	TObjectPtr<UNiagaraSystem> GetTileNiagaraSys() { return tileNiagaraSys_; }
+	inline TObjectPtr<UNiagaraSystem> GetTileNiagaraSys() { return tileNiagaraSys_; }
 
 	// 配列内のマスの番号のゲッター
-	FVector2D GetTileArrayIndex() { return tileArrayIndex_; }
+	UFUNCTION(BlueprintCallable)
+	inline FVector2D GetTileArrayIndex() { return tileArrayIndex_; }
+
+
+	// canMove_のゲッター
+	UFUNCTION(BlueprintCallable)
+	inline bool GetCanMove() { return canMove_; }
 
 
 	// ----------------------------------------------------------------------------------
 	// セッター
 
 	// マスの種類のセッター
-	void SetTileType(E_TILE_TYPE tileType) { tileType_ = tileType; }
+	UFUNCTION(BlueprintCallable)
+	inline void SetTileType(E_TILE_TYPE tileType) { tileType_ = tileType; }
 
 	// マスのナイアガラのセッター
-	void SetTileNiagaraSys(TObjectPtr<UNiagaraSystem> tileNiagaraSys) { tileNiagaraSys_ = tileNiagaraSys; }
+	inline void SetTileNiagaraSys(TObjectPtr<UNiagaraSystem> tileNiagaraSys) { tileNiagaraSys_ = tileNiagaraSys; }
 
 	// 配列内のマスの番号のセッター
-	void SetTileArrayIndex(FVector2D tileArrayIndex) { tileArrayIndex_ = tileArrayIndex; }
+	UFUNCTION(BlueprintCallable)
+	inline void SetTileArrayIndex(FVector2D tileArrayIndex) { tileArrayIndex_ = tileArrayIndex; }
+
+	// canMove_のセッター
+	UFUNCTION(BlueprintCallable)
+	inline void SetCanMove(bool canMove) { canMove_ = canMove; }
 
 };

--- a/Source/SpaceExploration/Public/Scene/SelectTileScene/AC_MapTile.h
+++ b/Source/SpaceExploration/Public/Scene/SelectTileScene/AC_MapTile.h
@@ -25,16 +25,7 @@ public:
 	// コンストラクタ
 	AAC_MapTileBase();
 
-	// マスの種類のゲッター
-	UFUNCTION(BlueprintCallable)
-	inline E_TILE_TYPE getTileType() { return tileType_; }
 
-	// マスのイベントが完了したか判定を返す
-	UFUNCTION(BlueprintCallable)
-	bool IsEventCompleted()
-	{
-		return bIsEvnetCompleted;
-	}
 
 protected:
 	// Called when the game starts or when spawned
@@ -43,13 +34,21 @@ protected:
 	// マスで実行するイベントが終了しているかどうか
 	// デフォルト値はfalse
 	UPROPERTY(EditAnywhere)
-	bool isTileEventEnd;
+	bool isTileEventEnd_;
 
 	// マスの種類の変数
 	// デフォルト値はNONE
 	UPROPERTY(EditAnywhere)
 	E_TILE_TYPE tileType_;
 
+	// マスのマップ上での位置
+	// データを生成した際にセットも行うこと
+	UPROPERTY(VisibleAnywhere)
+	FVector2D tileIndex_;
+
+	// このマスに移動できる状態かどうかを表す
+	UPROPERTY(EditAnywhere)
+	bool canMove_;
 
 
 	//------------------------------------------------------------------
@@ -87,13 +86,42 @@ public:
 	virtual void Tick(float DeltaTime) override;
 
 
+	// ======================================================================================================
+	// マスのイベント関連
+
+	// ----------------------------------------------------------------------------------
 	// マスで実行するイベントの関数
 	// 継承先でこの関数をオーバーライドして処理を作成する
 	virtual void TileEvent() PURE_VIRTUAL(AAC_MapTileBase::TileEvent, );
 
+
+	// ----------------------------------------------------------------------------------
 	// マスのイベント実行中の処理関数
 	virtual void TileEventRunning() PURE_VIRTUAL(AAC_MapTileBase::TileEventRunning, );
 
+
+	// ----------------------------------------------------------------------------------
+	// マスのイベントが完了したか判定を返す
+	UFUNCTION(BlueprintCallable)
+	bool IsEventCompleted()
+	{
+		return bIsEvnetCompleted;
+	}
+
+
+	// ======================================================================================================
+	// ゲッターセッター
+
+
+
+	// ----------------------------------------------------------------------------------
+	// マスの種類のゲッター
+	UFUNCTION(BlueprintCallable)
+	inline E_TILE_TYPE getTileType() { return tileType_; }
+
+
+
+	// ----------------------------------------------------------------------------------
 	// スタティックメッシュをセットする関数
 	// 引数：fileName...スタティックメッシュの保存先のパス
 	// 
@@ -101,7 +129,7 @@ public:
 	void SetStaticMesh(const TCHAR* fileName);
 
 
-
+	// ----------------------------------------------------------------------------------
 	// ナイアガラシステムをセットする関数
 	// 引数：planetNiagaraComp...セットするナイアガラ
 	inline void SetNiagaraSystem( TObjectPtr<UNiagaraSystem> niagaraSystem) {
@@ -112,6 +140,44 @@ public:
 	}
 
 
+	// ----------------------------------------------------------------------------------
+	// tileIndex_のゲッター
+	UFUNCTION(BlueprintCallable)
+	inline FVector2D GetTileIndex() {
+
+		return tileIndex_;
+	}
+
+
+	// ----------------------------------------------------------------------------------
+	// tileIndex_のセッター
+	UFUNCTION(BlueprintCallable)
+	inline void SetTileIndex(FVector2D tileIndex) {
+
+		tileIndex_ = tileIndex;
+	}
+
+
+	// ----------------------------------------------------------------------------------
+	// canMove_のゲッター
+	// 主に移動前に移動可能か確認を行う際に使用（予定）
+	inline bool GetCanMove() {
+
+		return canMove_;
+	}
+
+	// ----------------------------------------------------------------------------------
+	// canMove_のセッター
+	// 主にマスのイベント終了時に次に移動できるマスを変更するのに使用（予定）
+	inline void SetCanMove(bool newCanMove) {
+
+		canMove_ = newCanMove;
+	}
+
+
+
+	// ======================================================================================================
+	// その他
 
 	// 左クリックをされた時の処理を行う。
 	// プレイヤーを自身の惑星まで移動させる。


### PR DESCRIPTION
移動できるマスを現在のマスのひとつ先の列のマスのみに変更

〇AC_MapTileBase, TileData
　マスに移動できるかどうかに関するフラグを作成

〇その他
　上で作成したフラグに応じて移動の処理ができるかどうか判定を行うように変更